### PR TITLE
Fix route controller example

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ class TestController
 }
 
 // routes.php
-Router::get('route/uri', '\App\Http\Controllers@show');
+Router::get('route/uri', '\App\Http\TestController@show');
 ```
 
 #### Map


### PR DESCRIPTION
Should be using name of class

From
```
Router::get('route/uri', '\App\Http\Controllers@show');
```
To
```
Router::get('route/uri', '\App\Http\TestController@show');
```

```php
// app/Http/Controllers/TestController.php
namespace App\Http\Controllers;

class TestController
{
    public function show()
    {
        return 'Hello World';
    }
}
```