### PR TITLE
Ignore vendor folder for standalone dev installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+vendor/*


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you read the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------

When setting up lumberjack as a separate packaged theme the vendor folder should be ignored.

Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)

Any other comments?
-------------------
…
