### PR TITLE
Auto-register menus from 'config/menus.php'

### DIFF
--- a/app/Http/Lumberjack.php
+++ b/app/Http/Lumberjack.php
@@ -3,6 +3,7 @@
 namespace App\Http;
 
 use Rareloop\Lumberjack\Http\Lumberjack as LumberjackCore;
+use Rareloop\Lumberjack\Facades\Config;
 use App\Menu\Menu;
 
 class Lumberjack extends LumberjackCore
@@ -18,7 +19,13 @@ class Lumberjack extends LumberjackCore
         // the context, you can get items from it in a way that is a little smoother and more
         // versatile than Wordpress's wp_nav_menu. (You need never again rely on a
         // crazy "Walker Function!")
-        $context['menu'] = new Menu('main-nav');
+        
+        // Auto-register menus from 'config/menus.php'
+        if (!empty( $menus = Config::get('menus.menus') ) ) {
+            foreach( $menus as $key => $value ) {
+                $context[$key] = new Menu( $key );
+            }
+        }
 
         return $context;
     }


### PR DESCRIPTION
What does this implement/fix?
---------------------------------------------------
Out of the box, Lumberjack only registers one nav menu, "main-nav" in `/config/menus.php`, then manually adds that navigation Menu to the context in `/app/Http/Lumberjack.php`.

As currently implemented, this doesn't seem very DRY as it requires manually hard-coding the registered menus into the Lumberjack class. This pull request aims to rectify that.

Looking through the docs, I wasn't sure if there's a preferred way to register multiple navigation menus and add them to context, so I tried to build on the current implementation. If there's a better way to register new nav menus and add them to the context, please let me know.

Any other comments?
-------------------
Twig doesn't like it when you use a dash (`-`) in a variable/attribute name, since Twig will interpret the dash as a minus operator. But registering navigation menus with underscores instead of dashes doesn't seem to be the "WordPress way". So if anyone wanted to use the default "main-nav" in their Twig templates, they'd have to use Twig's `attribute()` function, for example:
```
{% for item in attribute(_context, 'main-nav').items %}
    // Access item.title, item.link, etc.
{% endfor %}
```

